### PR TITLE
ターゲットフレームワークを .NET 8.0 に更新

### DIFF
--- a/aup2exo/aup2exo.csproj
+++ b/aup2exo/aup2exo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>0.1.1</Version>
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="Karoterra.AupDotNet" Version="0.1.1" />
+    <PackageReference Include="Karoterra.AupDotNet" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET 6 のサポート期間が終了したためターゲットフレームワークを次のLTSである .NET 8 に更新した。
あわせてAupDotNetも更新しているため、以下の修正が反映されている。
https://github.com/karoterra/AupDotNet/pull/5